### PR TITLE
“:bug: FIX: 목표금액 비교 부분 오류 해결

### DIFF
--- a/money-log/src/components/GoalTracker.vue
+++ b/money-log/src/components/GoalTracker.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { onMounted } from 'vue'
+import { computed, onMounted } from 'vue'
 import { useGoalStore } from '@/stores/goal'
 import { useTransactionStore } from '@/stores/transactionStore'
 import DonutChart from './DonutChart.vue'
@@ -12,6 +12,14 @@ onMounted(() => {
   goalStore.getGoalInfo()
   transactionStore.getTransactionInfo()
 })
+
+// 현재 월 (YYYY-MM) 구하기
+const currentMonth = new Date().toISOString().slice(0, 7)
+
+// 해당 월의 지출 합계 계산
+const currentMonthExpense = computed(() =>
+  transactionStore.monthTotalExpense(currentMonth),
+)
 </script>
 
 <template>
@@ -30,7 +38,7 @@ onMounted(() => {
       <div class="label">
         <p class="label-name">현재까지의 소비</p>
         <span class="label-value nowspend">
-          {{ transactionStore.totalExpense.toLocaleString() }}원
+          {{ currentMonthExpense.toLocaleString() }}원
         </span>
       </div>
     </div>


### PR DESCRIPTION
- 오류1: 소비 금액 불일치
- 오류2: 목표 금액에 대한 사용 금액의 비가 100%가 되어도 차트 미반영
- src/components/MostSpent.vue 파일 코드 수정
- db.json의 currentExpense를 그대로 가져오던 것에서 스토어의 해당 부분 사용하는 것으로 변경
- 도넛 차트의 미반영 문제 해결